### PR TITLE
Remove resize event listener as component unmounts

### DIFF
--- a/src/Viewport/withViewport.js
+++ b/src/Viewport/withViewport.js
@@ -18,7 +18,7 @@ export default (WrappedComponent, sizes) => {
       this.listener = window.addEventListener("resize", this.onResize);
     }
 
-    componentWillMount(){
+    componentWillUnmount(){
       window.removeEventListener("resize", this.onResize);
     }
 


### PR DESCRIPTION
Previously it would be possible for onResize to execute even though the instance of withViewport that created that listener had been unmounted.

This results in a setState call to a component which doesn't exist, removing the listener during componentWillUnmount stops that possibility.

Example:

![image](https://user-images.githubusercontent.com/20520093/76554652-23624d80-648e-11ea-8bb8-10b0b8a83436.png)
